### PR TITLE
Add login page

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,9 @@ A simple Django-based blog project.
 The project now includes a minimal signup page where users can create an account
 with a unique username and email. Passwords are validated using Django's default
 password validators and are securely hashed.
+
+## Login Feature
+
+A lightweight login page lets existing users sign in with their username or
+email address and password. After authenticating, users are redirected to the
+homepage.

--- a/aiblogsite/accounts/forms.py
+++ b/aiblogsite/accounts/forms.py
@@ -2,7 +2,8 @@
 
 from django import forms
 from django.contrib.auth import get_user_model
-from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.forms import AuthenticationForm, UserCreationForm
+from django.contrib.auth import authenticate
 
 User = get_user_model()
 
@@ -21,3 +22,29 @@ class SignupForm(UserCreationForm):
         if User.objects.filter(email__iexact=email).exists():
             raise forms.ValidationError("A user with that email already exists.")
         return email
+
+
+class LoginForm(AuthenticationForm):
+    """Authentication form accepting username or email."""
+
+    username = forms.CharField(label="Username or Email")
+
+    def clean(self):
+        username_or_email = self.cleaned_data.get("username")
+        password = self.cleaned_data.get("password")
+
+        if username_or_email and password:
+            user_model = get_user_model()
+            try:
+                user_obj = user_model.objects.get(email__iexact=username_or_email)
+                username = user_obj.get_username()
+            except user_model.DoesNotExist:
+                username = username_or_email
+
+            self.user_cache = authenticate(self.request, username=username, password=password)
+            if self.user_cache is None:
+                raise forms.ValidationError(self.error_messages["invalid_login"], code="invalid_login")
+            else:
+                self.confirm_login_allowed(self.user_cache)
+
+        return self.cleaned_data

--- a/aiblogsite/accounts/templates/accounts/login.html
+++ b/aiblogsite/accounts/templates/accounts/login.html
@@ -1,11 +1,31 @@
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Login</title>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
 </head>
-<body>
-    
+<body class="bg-gray-100 flex items-center justify-center min-h-screen">
+    <div class="w-full max-w-md bg-white p-6 rounded shadow">
+        <h1 class="text-2xl font-bold mb-4 text-center">AI Blog Login</h1>
+        <form method="post" novalidate class="space-y-4">
+            {% csrf_token %}
+            {{ form.non_field_errors }}
+            <div>
+                {{ form.username.label_tag }}
+                {{ form.username }}
+                {{ form.username.errors }}
+            </div>
+            <div>
+                {{ form.password.label_tag }}
+                {{ form.password }}
+                {{ form.password.errors }}
+            </div>
+            <button type="submit" class="w-full py-2 px-4 bg-blue-600 text-white rounded">Login</button>
+        </form>
+        <p class="mt-4 text-center text-sm">Don't have an account? <a href="{% url 'accounts:signup' %}" class="text-blue-600">Sign Up</a></p>
+    </div>
 </body>
 </html>

--- a/aiblogsite/accounts/tests.py
+++ b/aiblogsite/accounts/tests.py
@@ -58,3 +58,34 @@ class SignupTests(TestCase):
             },
         )
         self.assertContains(response, "This password is too short", status_code=200)
+
+
+class LoginTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            "loginuser",
+            "login@example.com",
+            "StrongPass123",
+        )
+
+    def test_login_with_username(self):
+        response = self.client.post(
+            reverse("accounts:login"),
+            {"username": "loginuser", "password": "StrongPass123"},
+        )
+        self.assertRedirects(response, reverse("home"))
+
+    def test_login_with_email(self):
+        response = self.client.post(
+            reverse("accounts:login"),
+            {"username": "login@example.com", "password": "StrongPass123"},
+        )
+        self.assertRedirects(response, reverse("home"))
+
+    def test_invalid_credentials(self):
+        response = self.client.post(
+            reverse("accounts:login"),
+            {"username": "bad", "password": "wrong"},
+        )
+        self.assertContains(response, "Please enter a correct", status_code=200)

--- a/aiblogsite/accounts/urls.py
+++ b/aiblogsite/accounts/urls.py
@@ -6,4 +6,5 @@ app_name = "accounts"
 
 urlpatterns = [
     path("signup/", views.signup, name="signup"),
+    path("login/", views.login_view, name="login"),
 ]

--- a/aiblogsite/accounts/views.py
+++ b/aiblogsite/accounts/views.py
@@ -4,7 +4,7 @@ from django.contrib.auth import login
 from django.shortcuts import redirect, render
 from django.views.decorators.http import require_http_methods
 
-from .forms import SignupForm
+from .forms import LoginForm, SignupForm
 
 
 @require_http_methods(["GET", "POST"])
@@ -19,3 +19,20 @@ def signup(request):
     else:
         form = SignupForm()
     return render(request, "accounts/signup.html", {"form": form})
+
+
+@require_http_methods(["GET", "POST"])
+def login_view(request):
+    """Authenticate user by username or email and redirect to home."""
+    if request.user.is_authenticated:
+        return redirect("home")
+
+    if request.method == "POST":
+        form = LoginForm(request, data=request.POST)
+        if form.is_valid():
+            login(request, form.get_user())
+            return redirect("home")
+    else:
+        form = LoginForm()
+
+    return render(request, "accounts/login.html", {"form": form})

--- a/aiblogsite/blog/templates/blog/landing.html
+++ b/aiblogsite/blog/templates/blog/landing.html
@@ -21,8 +21,8 @@
         </a>
         <nav class="flex items-center space-x-6">
             <a href="/blog/" class="text-gray-700 hover:text-blue-600 font-medium">Blog</a>
-            <a href="/login/" class="text-gray-700 hover:text-blue-600 font-medium">Login</a>
-            <a href="/accounts/signup/" class="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 font-medium">Signup</a>
+            <a href="{% url 'accounts:login' %}" class="text-gray-700 hover:text-blue-600 font-medium">Login</a>
+            <a href="{% url 'accounts:signup' %}" class="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 font-medium">Signup</a>
         </nav>
     </header>
 


### PR DESCRIPTION
## Summary
- implement custom LoginForm to allow username or email
- add login view and URL routes
- create Tailwind-styled login template
- update landing page links
- extend README
- add tests for login behavior

## Testing
- `python aiblogsite/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687bb9ac9d548324a2642b4fc76ca144