### PR TITLE
AI-18: Add Terms page

### DIFF
--- a/aiblogsite/blog/templates/blog/base.html
+++ b/aiblogsite/blog/templates/blog/base.html
@@ -21,6 +21,7 @@
                 <a href="{% url 'blog_home' %}" class="{% if request.resolver_match.url_name == 'blog_home' %}text-blue-600 font-semibold border-b-2 border-blue-600{% else %}hover:text-blue-600{% endif %}">Blog</a>
                 <a href="{% url 'about' %}" class="{% if request.resolver_match.url_name == 'about' %}text-blue-600 font-semibold border-b-2 border-blue-600{% else %}hover:text-blue-600{% endif %}">About</a>
                 <a href="{% url 'contact' %}" class="{% if request.resolver_match.url_name == 'contact' %}text-blue-600 font-semibold border-b-2 border-blue-600{% else %}hover:text-blue-600{% endif %}">Contact</a>
+                <a href="{% url 'terms' %}" class="{% if request.resolver_match.url_name == 'terms' %}text-blue-600 font-semibold border-b-2 border-blue-600{% else %}hover:text-blue-600{% endif %}">Terms</a>
                 <a href="{% url 'accounts:auth_split' %}" class="hover:text-blue-600">Authenticate</a>
                 <a href="{% url 'accounts:login' %}" class="px-4 py-1 border border-blue-600 text-blue-600 rounded hover:bg-blue-50">Login</a>
                 <a href="{% url 'accounts:signup' %}" class="px-4 py-1 bg-blue-600 text-white rounded hover:bg-blue-700">Sign Up</a>
@@ -32,6 +33,7 @@
                 <a href="{% url 'blog_home' %}" class="{% if request.resolver_match.url_name == 'blog_home' %}text-blue-600 font-semibold border-b-2 border-blue-600{% else %}hover:text-blue-600{% endif %}">Blog</a>
                 <a href="{% url 'about' %}" class="{% if request.resolver_match.url_name == 'about' %}text-blue-600 font-semibold border-b-2 border-blue-600{% else %}hover:text-blue-600{% endif %}">About</a>
                 <a href="{% url 'contact' %}" class="{% if request.resolver_match.url_name == 'contact' %}text-blue-600 font-semibold border-b-2 border-blue-600{% else %}hover:text-blue-600{% endif %}">Contact</a>
+                <a href="{% url 'terms' %}" class="{% if request.resolver_match.url_name == 'terms' %}text-blue-600 font-semibold border-b-2 border-blue-600{% else %}hover:text-blue-600{% endif %}">Terms</a>
                 <a href="{% url 'accounts:login' %}" class="hover:text-blue-600">Login</a>
                 <a href="{% url 'accounts:signup' %}" class="hover:text-blue-600">Sign Up</a>
                 <a href="{% url 'accounts:auth_split' %}" class="hover:text-blue-600">Authenticate</a>
@@ -56,7 +58,7 @@
             </div>
             <div class="text-sm flex flex-col space-y-2">
                 <a href="/blog/" class="hover:text-white">Blog</a>
-                <a href="/terms/" class="hover:text-white">Terms of Use</a>
+                <a href="/terms/" class="hover:text-white">Terms of Service</a>
                 <a href="/privacy/" class="hover:text-white">Privacy Policy</a>
                 <a href="/cancellation/" class="hover:text-white">Cancellation</a>
                 <a href="/contact/" class="hover:text-white">Contact</a>

--- a/aiblogsite/blog/templates/blog/terms.html
+++ b/aiblogsite/blog/templates/blog/terms.html
@@ -1,0 +1,98 @@
+{% extends "blog/base.html" %}
+{% block title %}Terms and Conditions - AI Insights{% endblock %}
+{% block body_class %}min-h-screen flex flex-col bg-[#F8F9FB] text-gray-800{% endblock %}
+
+{% block content %}
+    <!-- Hero Section -->
+    <section class="text-center px-6 py-16 bg-white">
+        <span class="text-sm font-medium bg-blue-600 text-white px-3 py-1 rounded-full mb-4 inline-block">Legal Center</span>
+        <h1 class="text-4xl sm:text-5xl font-extrabold mb-4">Terms and <span class="text-[#5171FF]">Conditions</span></h1>
+        <p class="text-gray-500 max-w-2xl mx-auto">These terms govern your use of our website and services. Please read them carefully as continued use implies your acceptance and agreement with these usage insights.</p>
+    </section>
+
+    <!-- Terms Card -->
+    <section class="flex-1 px-6 py-12">
+        <div class="bg-white rounded-2xl shadow max-w-3xl mx-auto p-8 space-y-10">
+            <div class="space-y-3">
+                <div class="flex items-center space-x-3">
+                    <div class="h-8 w-8 rounded-full flex items-center justify-center bg-blue-100">
+                        <svg class="w-5 h-5 text-[#5171FF]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M9 12l2 2 4-4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/></svg>
+                    </div>
+                    <h2 class="font-semibold text-lg">Acceptance of Terms</h2>
+                </div>
+                <p class="text-sm text-gray-600">By accessing AI Insights, you agree to abide by these Terms and all applicable laws.</p>
+            </div>
+            <div class="space-y-3">
+                <div class="flex items-center space-x-3">
+                    <div class="h-8 w-8 rounded-full flex items-center justify-center bg-purple-100">
+                        <svg class="w-5 h-5 text-[#A366FF]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><circle cx="12" cy="7" r="4"/><path d="M5.5 21v-2a4.5 4.5 0 014.5-4.5h4a4.5 4.5 0 014.5 4.5v2" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/></svg>
+                    </div>
+                    <h2 class="font-semibold text-lg">User Responsibilities</h2>
+                </div>
+                <ul class="list-disc pl-10 text-sm text-gray-600 space-y-1">
+                    <li>Provide accurate information.</li>
+                    <li>Use the site for lawful purposes only.</li>
+                    <li>Respect intellectual property rights.</li>
+                </ul>
+            </div>
+            <div class="space-y-3">
+                <div class="flex items-center space-x-3">
+                    <div class="h-8 w-8 rounded-full flex items-center justify-center bg-green-100">
+                        <svg class="w-5 h-5 text-[#19C37D]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/></svg>
+                    </div>
+                    <h2 class="font-semibold text-lg">Intellectual Property</h2>
+                </div>
+                <p class="text-sm text-gray-600">All content on AI Insights is owned by us or our licensors and protected by copyright laws.</p>
+            </div>
+            <div class="space-y-3">
+                <div class="flex items-center space-x-3">
+                    <div class="h-8 w-8 rounded-full flex items-center justify-center bg-orange-100">
+                        <svg class="w-5 h-5 text-[#FFB547]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/></svg>
+                    </div>
+                    <h2 class="font-semibold text-lg">Content and Conduct</h2>
+                </div>
+                <ul class="list-disc pl-10 text-sm text-gray-600 space-y-1">
+                    <li>No abusive or unlawful content.</li>
+                    <li>Do not impersonate others or misrepresent information.</li>
+                </ul>
+            </div>
+            <div class="space-y-3">
+                <div class="flex items-center space-x-3">
+                    <div class="h-8 w-8 rounded-full flex items-center justify-center bg-red-100">
+                        <svg class="w-5 h-5 text-[#E65353]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15" stroke-linecap="round" stroke-width="2"/><line x1="9" y1="9" x2="15" y2="15" stroke-linecap="round" stroke-width="2"/></svg>
+                    </div>
+                    <h2 class="font-semibold text-lg">Limitation of Liability</h2>
+                </div>
+                <p class="text-sm text-gray-600">AI Insights is provided “as is” without warranties. We are not liable for any damages arising from your use of the site.</p>
+            </div>
+            <div class="space-y-3">
+                <div class="flex items-center space-x-3">
+                    <div class="h-8 w-8 rounded-full flex items-center justify-center bg-blue-100">
+                        <svg class="w-5 h-5 text-[#5171FF]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path d="M4 4v6h6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/><path d="M20 20v-6h-6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/><path d="M5 19L19 5" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/></svg>
+                    </div>
+                    <h2 class="font-semibold text-lg">Modifications to Terms</h2>
+                </div>
+                <p class="text-sm text-gray-600">We may update these Terms periodically. Continued use after changes signifies acceptance.</p>
+            </div>
+            <div class="space-y-3">
+                <div class="flex items-center space-x-3">
+                    <div class="h-8 w-8 rounded-full flex items-center justify-center bg-purple-100">
+                        <svg class="w-5 h-5 text-[#A366FF]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path d="M7 20h10" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/><path d="M12 14v-7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/><path d="M5 13l7-7 7 7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/></svg>
+                    </div>
+                    <h2 class="font-semibold text-lg">Governing Law</h2>
+                </div>
+                <p class="text-sm text-gray-600">These Terms are governed by the laws of our principal place of business.</p>
+            </div>
+            <div class="space-y-3 bg-[#F8F9FB] p-4 rounded-lg">
+                <div class="flex items-center space-x-3">
+                    <div class="h-8 w-8 rounded-full flex items-center justify-center bg-blue-100">
+                        <svg class="w-5 h-5 text-[#5171FF]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path d="M4 4h16v16H4z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/><polyline points="22,6 12,13 2,6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/></svg>
+                    </div>
+                    <h2 class="font-semibold text-lg">Contact Information</h2>
+                </div>
+                <p class="text-sm text-gray-600">Questions? Reach us at <a href="mailto:legal@aiinsights.com" class="text-blue-600 underline">legal@aiinsights.com</a>.</p>
+            </div>
+            <div class="text-xs text-gray-500 text-right">Last updated: 2024</div>
+        </div>
+    </section>
+{% endblock %}

--- a/aiblogsite/blog/tests.py
+++ b/aiblogsite/blog/tests.py
@@ -22,3 +22,12 @@ class ContactTests(TestCase):
         response = self.client.post(reverse('contact'), data)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(ContactMessage.objects.filter(email='tester@example.com').exists())
+
+
+class TermsTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    def test_get_terms_page(self):
+        response = self.client.get(reverse('terms'))
+        self.assertEqual(response.status_code, 200)

--- a/aiblogsite/blog/urls.py
+++ b/aiblogsite/blog/urls.py
@@ -6,4 +6,5 @@ urlpatterns = [
     path('blog/', views.blog_home, name='blog_home'),
     path('about/', views.about, name='about'),
     path('contact/', views.contact, name='contact'),
+    path('terms/', views.terms, name='terms'),
 ]

--- a/aiblogsite/blog/views.py
+++ b/aiblogsite/blog/views.py
@@ -45,3 +45,11 @@ def contact(request):
 
     context = {"form": form, "year": datetime.now().year}
     return render(request, "blog/contact.html", context)
+
+
+def terms(request):
+    """Render the Terms and Conditions page."""
+    from datetime import datetime
+
+    context = {"year": datetime.now().year}
+    return render(request, "blog/terms.html", context)


### PR DESCRIPTION
## Summary
- create Terms and Conditions page template
- route `terms/` to new view
- link Terms page in navigation and footer
- test that terms view renders

## Testing
- `pytest` *(fails: no tests collected)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687eb12c4c5c8324907f1f6b484631c3