### PR TITLE
AI-28: add post creation page

### DIFF
--- a/blog/forms.py
+++ b/blog/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from .models import ContactMessage
+from .models import ContactMessage, Post
 
 
 class ContactForm(forms.ModelForm):
@@ -11,4 +11,25 @@ class ContactForm(forms.ModelForm):
         }
         labels = {
             "agree": "I agree to the Privacy Policy and Terms of Service",
+        }
+
+
+class PostForm(forms.ModelForm):
+    """Form for creating blog posts."""
+
+    class Meta:
+        model = Post
+        fields = [
+            "title",
+            "slug",
+            "excerpt",
+            "content",
+            "featured_image_url",
+            "status",
+            "categories",
+            "tags",
+        ]
+        widgets = {
+            "categories": forms.CheckboxSelectMultiple,
+            "tags": forms.CheckboxSelectMultiple,
         }

--- a/blog/templates/blog/_post_form.html
+++ b/blog/templates/blog/_post_form.html
@@ -1,0 +1,20 @@
+{% load widget_tweaks %}
+<form hx-post="{% url 'add_post' %}" hx-target="#form-container" hx-swap="outerHTML" method="post" class="space-y-4">
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    {{ form.title|add_class:'w-full px-4 py-2 border border-gray-300 rounded' }}
+    {{ form.slug|add_class:'w-full px-4 py-2 border border-gray-300 rounded' }}
+    {{ form.excerpt|add_class:'w-full px-4 py-2 border border-gray-300 rounded' }}
+    {{ form.content|add_class:'w-full px-4 py-2 border border-gray-300 rounded' }}
+    {{ form.featured_image_url|add_class:'w-full px-4 py-2 border border-gray-300 rounded' }}
+    {{ form.status|add_class:'w-full px-4 py-2 border border-gray-300 rounded' }}
+    <div>
+        <label class="block font-semibold mb-2">Categories</label>
+        {{ form.categories }}
+    </div>
+    <div>
+        <label class="block font-semibold mb-2">Tags</label>
+        {{ form.tags }}
+    </div>
+    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Save Post</button>
+</form>

--- a/blog/templates/blog/add_post.html
+++ b/blog/templates/blog/add_post.html
@@ -1,0 +1,10 @@
+{% extends "blog/base.html" %}
+{% block title %}Add Post{% endblock %}
+{% block content %}
+<section class="max-w-3xl mx-auto px-6 py-12">
+    <h1 class="text-3xl font-bold mb-6">Add Post</h1>
+    <div id="form-container">
+        {% include "blog/_post_form.html" %}
+    </div>
+</section>
+{% endblock %}

--- a/blog/templates/blog/add_post_success.html
+++ b/blog/templates/blog/add_post_success.html
@@ -1,0 +1,1 @@
+<div class="bg-green-100 text-green-700 p-4 rounded">Post "{{ post.title }}" created successfully!</div>

--- a/blog/templates/blog/base.html
+++ b/blog/templates/blog/base.html
@@ -71,6 +71,7 @@
                 <a href="{% url 'cancellation' %}" aria-label="Cancellation and Refund Policy" class="hover:text-white">Cancellation &amp; Refund Policy</a>
                 <a href="{% url 'contact' %}" aria-label="Contact" class="hover:text-white">Contact</a>
                 <a href="{% url 'about' %}" aria-label="About" class="hover:text-white">About</a>
+                <a href="{% url 'add_post' %}" aria-label="Add Post" class="hover:text-white">Add Post</a>
             </div>
             <div>
                 <form hx-post="#" hx-target="#footer-message" hx-swap="outerHTML" class="flex flex-col sm:flex-row gap-3">

--- a/blog/urls.py
+++ b/blog/urls.py
@@ -10,4 +10,5 @@ urlpatterns = [
     path('privacy/', views.privacy, name='privacy'),
     path('terms/', views.terms, name='terms'),
     path('cancellation/', views.cancellation, name='cancellation'),
+    path('add_post/', views.add_post, name='add_post'),
 ]


### PR DESCRIPTION
## Summary
- create PostForm for adding posts
- allow adding posts via new view and URL
- include templates for add_post
- link to the page from footer

## Testing
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_6881eddc99248324a759d39c4066eb3c