### PR TITLE
Add password reset support

### DIFF
--- a/accounts/templates/accounts/auth_split.html
+++ b/accounts/templates/accounts/auth_split.html
@@ -76,7 +76,7 @@
                 <div class="text-red-500 text-sm">{{ error }}</div>
                 {% endfor %}
                 <button type="submit" class="w-full py-3 text-white font-semibold rounded bg-gradient-to-r from-[#5171FF] to-[#A366FF] hover:shadow-md">Log In</button>
-                <p class="text-center text-sm mt-6">Don't have an account? <a href="#" id="switchToLogin" class="text-[#347CFF] underline">Sign up</a></p>
+                <p class="text-center text-sm mt-6">Don't have an account? <a href="#" id="switchToLogin" class="text-[#347CFF] underline">Sign up</a> | <a href="{% url 'accounts:password_reset' %}" class="text-[#347CFF] underline">Forgot password?</a></p>
             </form>
         </div>
     </div>

--- a/accounts/templates/accounts/password_reset_complete.html
+++ b/accounts/templates/accounts/password_reset_complete.html
@@ -1,0 +1,8 @@
+{% extends "blog/base.html" %}
+{% block title %}Password Reset Complete - HowAiworks{% endblock %}
+{% block content %}
+<div class="max-w-md mx-auto py-12 text-center">
+    <h1 class="text-2xl font-semibold mb-4">Password changed</h1>
+    <p>Your password has been set. You may now <a href="{% url 'accounts:auth_split' %}?form=login" class="text-[#347CFF] underline">log in</a>.</p>
+</div>
+{% endblock %}

--- a/accounts/templates/accounts/password_reset_confirm.html
+++ b/accounts/templates/accounts/password_reset_confirm.html
@@ -1,0 +1,19 @@
+{% extends "blog/base.html" %}
+{% load widget_tweaks %}
+{% block title %}Set New Password - HowAiworks{% endblock %}
+{% block content %}
+<div class="max-w-md mx-auto py-12">
+    <h1 class="text-2xl font-semibold mb-4 text-center">Set a new password</h1>
+    <form method="post" class="space-y-4">
+        {% csrf_token %}
+        {{ form.new_password1|add_class:'w-full px-4 py-3 border border-gray-300 rounded' }}
+        {{ form.new_password2|add_class:'w-full px-4 py-3 border border-gray-300 rounded' }}
+        {% for field in form %}
+            {% for error in field.errors %}
+            <p class="text-red-500 text-sm">{{ error }}</p>
+            {% endfor %}
+        {% endfor %}
+        <button type="submit" class="w-full py-3 bg-[#5171FF] text-white rounded">Change password</button>
+    </form>
+</div>
+{% endblock %}

--- a/accounts/templates/accounts/password_reset_done.html
+++ b/accounts/templates/accounts/password_reset_done.html
@@ -1,0 +1,8 @@
+{% extends "blog/base.html" %}
+{% block title %}Password Reset Sent - HowAiworks{% endblock %}
+{% block content %}
+<div class="max-w-md mx-auto py-12 text-center">
+    <h1 class="text-2xl font-semibold mb-4">Check your inbox</h1>
+    <p>We've emailed you instructions for setting your password. You should receive the email shortly.</p>
+</div>
+{% endblock %}

--- a/accounts/templates/accounts/password_reset_email.txt
+++ b/accounts/templates/accounts/password_reset_email.txt
@@ -1,0 +1,4 @@
+You're receiving this email because you requested a password reset for your HowAiworks account.
+Please go to the following page and set a new password:
+{{ protocol }}://{{ domain }}{% url 'accounts:password_reset_confirm' uidb64=uid token=token %}
+If you didn't request this, please ignore this email.

--- a/accounts/templates/accounts/password_reset_form.html
+++ b/accounts/templates/accounts/password_reset_form.html
@@ -1,0 +1,17 @@
+{% extends "blog/base.html" %}
+{% load widget_tweaks %}
+{% block title %}Reset Password - HowAiworks{% endblock %}
+{% block content %}
+<div class="max-w-md mx-auto py-12">
+    <h1 class="text-2xl font-semibold mb-4 text-center">Forgot your password?</h1>
+    <p class="text-center text-gray-700 mb-6">Enter your email address below and we'll send you a link to reset your password.</p>
+    <form method="post" class="space-y-4">
+        {% csrf_token %}
+        {{ form.email|add_class:'w-full px-4 py-3 border border-gray-300 rounded' }}
+        {% for error in form.email.errors %}
+        <p class="text-red-500 text-sm">{{ error }}</p>
+        {% endfor %}
+        <button type="submit" class="w-full py-3 bg-[#5171FF] text-white rounded">Send reset link</button>
+    </form>
+</div>
+{% endblock %}

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,5 +1,12 @@
 from django.urls import path
 
+from .views import (
+    ForgotPasswordView,
+    ForgotPasswordDoneView,
+    ForgotPasswordConfirmView,
+    ForgotPasswordCompleteView,
+)
+
 from . import views
 
 app_name = "accounts"
@@ -12,4 +19,20 @@ urlpatterns = [
     path("reader_dashboard/", views.reader_dashboard, name="reader_dashboard"),
     path("author_dashboard/", views.author_dashboard, name="author_dashboard"),
     path("author_management/", views.author_management, name="author_management"),
+    path("password-reset/", ForgotPasswordView.as_view(), name="password_reset"),
+    path(
+        "password-reset/done/",
+        ForgotPasswordDoneView.as_view(),
+        name="password_reset_done",
+    ),
+    path(
+        "reset/<uidb64>/<token>/",
+        ForgotPasswordConfirmView.as_view(),
+        name="password_reset_confirm",
+    ),
+    path(
+        "reset/done/",
+        ForgotPasswordCompleteView.as_view(),
+        name="password_reset_complete",
+    ),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -2,8 +2,14 @@
 
 from django.contrib.auth import login, logout
 from django.contrib.auth.decorators import login_required, user_passes_test
+from django.contrib.auth.views import (
+    PasswordResetView,
+    PasswordResetDoneView,
+    PasswordResetConfirmView,
+    PasswordResetCompleteView,
+)
 from django.shortcuts import redirect, render
-from django.urls import reverse
+from django.urls import reverse, reverse_lazy
 from django.views.decorators.http import require_http_methods
 
 from .forms import LoginForm, SignupForm
@@ -101,3 +107,30 @@ def author_dashboard(request):
 def author_management(request):
     """Management panel reserved for superusers."""
     return render(request, "accounts/author_management.html")
+
+
+class ForgotPasswordView(PasswordResetView):
+    """Start password reset by sending an email to the user."""
+
+    template_name = "accounts/password_reset_form.html"
+    email_template_name = "accounts/password_reset_email.txt"
+    success_url = reverse_lazy("accounts:password_reset_done")
+
+
+class ForgotPasswordDoneView(PasswordResetDoneView):
+    """Display a message after the reset email is sent."""
+
+    template_name = "accounts/password_reset_done.html"
+
+
+class ForgotPasswordConfirmView(PasswordResetConfirmView):
+    """Allow the user to set a new password via the emailed link."""
+
+    template_name = "accounts/password_reset_confirm.html"
+    success_url = reverse_lazy("accounts:password_reset_complete")
+
+
+class ForgotPasswordCompleteView(PasswordResetCompleteView):
+    """Confirmation page shown after the password has been reset."""
+
+    template_name = "accounts/password_reset_complete.html"


### PR DESCRIPTION
## Summary
- provide a "Forgot password?" link on the login form
- add password reset views and routes
- create password reset templates

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6884c8437dd08324b249d2600098eb6f